### PR TITLE
Change subscription-manager path for RHEL 5/6 compat.

### DIFF
--- a/lib/puppet/provider/rh_repo/redhat.rb
+++ b/lib/puppet/provider/rh_repo/redhat.rb
@@ -1,6 +1,6 @@
 Puppet::Type.type(:rh_repo).provide(:redhat) do
 
-  commands :rhsm => '/sbin/subscription-manager'
+  commands :rhsm => '/usr/sbin/subscription-manager'
   mk_resource_methods
 
   def self.repos

--- a/lib/puppet/provider/rh_subscription/redhat.rb
+++ b/lib/puppet/provider/rh_subscription/redhat.rb
@@ -1,6 +1,6 @@
 Puppet::Type.type(:rh_subscription).provide(:redhat) do
 
-  commands :rhsm => '/sbin/subscription-manager'
+  commands :rhsm => '/usr/sbin/subscription-manager'
   mk_resource_methods
 
   def self.subscriptions


### PR DESCRIPTION
In order for this module to work on RHEL 5 and RHEL 6 hosts the subscription-manager command should point to /usr/sbin/, not /sbin/. I have tested this change on RHEL 5, RHEL 6 and RHEL 7 hosts.